### PR TITLE
Remove the region-based skips for cold storage

### DIFF
--- a/spec/084_cold_storage_spec.sh
+++ b/spec/084_cold_storage_spec.sh
@@ -53,12 +53,6 @@ Describe 'Put object with storage class' category:"ColdStorage" id:"084" id:"085
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "default-class")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --body "$file"
@@ -90,12 +84,6 @@ Describe 'Put object with storage class' category:"ColdStorage" id:"084" id:"085
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "standard-class")
     file="LICENSE"    
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --storage-class "STANDARD" --body "$file"
@@ -127,12 +115,6 @@ Describe 'Put object with storage class' category:"ColdStorage" id:"084" id:"085
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --storage-class "GLACIER_IR" --body "$file"
@@ -174,12 +156,6 @@ Describe 'List object with storage class' category:"ColdStorage" id:"085"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -205,12 +181,6 @@ Describe 'List object with storage class' category:"ColdStorage" id:"085"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -237,12 +207,6 @@ Describe 'List object with storage class' category:"ColdStorage" id:"085"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -278,12 +242,6 @@ Describe 'Object custom metadata with storage class' category:"ColdStorage" id:"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class-with-metadata")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --storage-class "GLACIER_IR" --body "$file" --metadata "metadata1=foo,metadata2=bar"
@@ -309,12 +267,6 @@ Describe 'Object custom metadata with storage class' category:"ColdStorage" id:"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class-with-metadata")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api head-object --profile "$profile" --bucket "$bucket_name" --key "$object_key"
@@ -347,12 +299,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
 
@@ -376,12 +322,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     # initiates a multipart upload passing a standard storage class argument
@@ -404,12 +344,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     # initiates a multipart upload passing a cold storage class argument
@@ -431,12 +365,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     profile=$1
     client=$2
     bucket_name=$(get_test_bucket_name)
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     count_standard() {
@@ -457,12 +385,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
   Example "upload parts with storage class default, on profile $1 using client $2"
     profile=$1
     client=$2
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     bucket_name=$(get_test_bucket_name)
@@ -494,12 +416,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     file_size=6
     file_unit="mb"
     create_file "$file_size" "$file_unit"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     # upload two parts
@@ -525,12 +441,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     file_size=6
     file_unit="mb"
     create_file "$file_size" "$file_unit"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     # upload two parts
@@ -553,12 +463,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     upload_id=$(cat "/tmp/$object_key.upload_id")
@@ -577,12 +481,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     upload_id=$(cat "/tmp/$object_key.upload_id")
@@ -601,12 +499,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     upload_id=$(cat "/tmp/$object_key.upload_id")
@@ -627,12 +519,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     upload_id=$(cat "/tmp/$object_key.upload_id")
@@ -653,12 +539,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     upload_id=$(cat "/tmp/$object_key.upload_id")
@@ -681,12 +561,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
     upload_id=$(cat "/tmp/$object_key.upload_id")
@@ -720,12 +594,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     local_file="" # will be overwritten by the function below
     file_size=6
     file_unit="mb"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     create_file "$file_size" "$file_unit"
     mgc workspace set $profile > /dev/null
     When run bash ./spec/retry_command.sh "mgc object-storage objects upload --src "$local_file" --dst "$bucket_name/$object_key" --raw"
@@ -755,19 +623,7 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     local_file="" # will be overwritten by the function below
     file_size=6
     file_unit="mb"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     create_file "$file_size" "$file_unit"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     mgc workspace set $profile > /dev/null
     When run mgc object-storage objects upload "$local_file" "$bucket_name/$object_key" --storage-class glacier_ir --raw
     The status should be success
@@ -781,12 +637,6 @@ Describe 'Multipart upload' category:"ColdStorage" id:"086"
     local_file="" # will be overwritten by the function below
     file_size=6
     file_unit="mb"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     create_file "$file_size" "$file_unit"
     mgc workspace set $profile > /dev/null
     When run mgc object-storage objects upload "$local_file" "$bucket_name/$object_key" --storage-class cold_instant --raw
@@ -805,12 +655,6 @@ Describe 'List multipart object with storage class' category:"ColdStorage" id:"0
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -836,12 +680,6 @@ Describe 'List multipart object with storage class' category:"ColdStorage" id:"0
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -867,12 +705,6 @@ Describe 'List multipart object with storage class' category:"ColdStorage" id:"0
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "multipart-glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -908,12 +740,6 @@ Describe 'Change the storage class of an existing…' category:"ColdStorage" id:
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "default-class")
     new_object_key=$(get_uploaded_key "default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api copy-object --bucket "$bucket_name" --key "$new_object_key" --storage-class "GLACIER_IR" --copy-source "$bucket_name/$object_key"
@@ -940,12 +766,6 @@ Describe 'Change the storage class of an existing…' category:"ColdStorage" id:
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "standard-class")
     new_object_key=$(get_uploaded_key "standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api copy-object --bucket "$bucket_name" --key "$new_object_key" --storage-class "GLACIER_IR" --copy-source "$bucket_name/$object_key"
@@ -998,12 +818,6 @@ Describe 'Change the storage class of an existing…' category:"ColdStorage" id:
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class")
     new_object_key=$(get_uploaded_key "glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api copy-object --bucket "$bucket_name" --key "$new_object_key" --storage-class "STANDARD" --copy-source "$bucket_name/$object_key"
@@ -1036,12 +850,6 @@ Describe 'List object with changed storage class' category:"ColdStorage" id:"087
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "default-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -1062,12 +870,6 @@ Describe 'List object with changed storage class' category:"ColdStorage" id:"087
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "standard-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       When run aws s3api list-objects-v2 --profile "$profile" --bucket "$bucket_name" --prefix "$object_key" --query "Contents[*].StorageClass"
@@ -1088,12 +890,6 @@ Describe 'List object with changed storage class' category:"ColdStorage" id:"087
     client=$2
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class")
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws" | "aws-s3")
       hard_wait
@@ -1125,12 +921,6 @@ Describe 'Put object with ACL and storage class' category:"ColdStorage" id:"089"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "default-class-with-acl")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --body "$file" --acl public-read
@@ -1151,12 +941,6 @@ Describe 'Put object with ACL and storage class' category:"ColdStorage" id:"089"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "standard-class-with-acl")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --body "$file" --acl public-read --storage-class "STANDARD"
@@ -1177,12 +961,6 @@ Describe 'Put object with ACL and storage class' category:"ColdStorage" id:"089"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class-with-acl")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       When run aws --profile "$profile" s3api put-object --bucket "$bucket_name" --key "$object_key" --body "$file" --acl public-read --storage-class "GLACIER_IR"
@@ -1214,12 +992,6 @@ Describe 'GET object ACL and storage class' category:"ColdStorage" id:"089"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "default-class-with-acl")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       trap wrong_storage_class ERR
@@ -1242,12 +1014,6 @@ Describe 'GET object ACL and storage class' category:"ColdStorage" id:"089"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "standard-class-with-acl")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       trap wrong_storage_class ERR
@@ -1270,12 +1036,6 @@ Describe 'GET object ACL and storage class' category:"ColdStorage" id:"089"
     bucket_name=$(get_test_bucket_name)
     object_key=$(get_uploaded_key "glacier-ir-class-with-acl")
     file="LICENSE"
-    region=$(aws configure get region --profile "$profile")
-    # Skip the test if the region is br-ne1
-    if [ "$region" = "br-ne1" ]; then
-      Skip "Skipping test: Region is br-ne1"
-      return 0
-    fi
     case "$client" in
     "aws-s3api" | "aws")
       # asserts that the storage class is the expected, if grep fails the test fails


### PR DESCRIPTION
We now have one ne region (br-ne1-yel) that does
have the Cold Storage feature.

And the test should be about the feature anyways,  so they should fail indeed on regions that dont
support Storage Class.